### PR TITLE
Feature/blobfix

### DIFF
--- a/sepolicy-ril/fsck.te
+++ b/sepolicy-ril/fsck.te
@@ -1,1 +1,2 @@
 allow fsck emmcblk_device:blk_file rw_file_perms;
+allow fsck tmpfs:blk_file rw_file_perms;

--- a/sepolicy-ril/fsck.te
+++ b/sepolicy-ril/fsck.te
@@ -1,2 +1,3 @@
 allow fsck emmcblk_device:blk_file rw_file_perms;
 allow fsck tmpfs:blk_file rw_file_perms;
+allowxperm fsck emmcblk_device:blk_file ioctl { BLKDISCARDZEROES BLKROGET BLKGETSIZE64 BLKGETSIZE BLKI2OSWSTRAT };

--- a/sepolicy-ril/rild.te
+++ b/sepolicy-ril/rild.te
@@ -50,3 +50,6 @@ allow audioserver rild:unix_stream_socket { connectto };
 allow rild audioserver:dir search;
 allow rild audioserver:file rw_file_perms;
 allow hal_sensors_default system_data_root_file:dir { open write };
+allow rild sysfs:file write;
+
+allow rild bin_nv_data_efs_file:file rw_file_perms;

--- a/sepolicy-ril/uncrypt.te
+++ b/sepolicy-ril/uncrypt.te
@@ -1,0 +1,1 @@
+allow uncrypt block_device:blk_file open;


### PR DESCRIPTION
se policy additions
Thanks to Jan Altensen for the information about extended sepolicy attributes:-
allowxperm fsck emmcblk_device:blk_file ioctl { BLKDISCARDZEROES BLKROGET BLKGETSIZE64 BLKGETSIZE BLKI2OSWSTRAT };
Fixes sepolicy denials for e2fsck

uncrypt requires open to allow OTA updates